### PR TITLE
Fix Gitpod configuration to use local Dockerfile

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,5 @@
-image: quay.io/nasa_genelab/gl4u:gl4u_rnaseq
+image:
+  file: .gitpod.Dockerfile
 
 tasks:
   - name: Setup Environment and Start Jupyter Lab


### PR DESCRIPTION
The .gitpod.yml was pointing to a pre-built image on quay.io, which meant the local .gitpod.Dockerfile was being ignored. This could lead to an environment that was not up-to-date with the dependencies specified in `environment.yml`.

This change updates .gitpod.yml to build the image from the local .gitpod.Dockerfile, ensuring that the Gitpod workspace is always created with the correct dependencies.